### PR TITLE
修复 heartbeat 不提供 vm_id 时出现异常的 bug

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -41,6 +41,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_POST( self ):
         log.debug("[POST request received]")
         datastr = self.rfile.read(int(self.headers['content-length']))
+        log.debug(datastr)
         data = json.loads(datastr)
         data['client_ip'] = self.client_address[0]
         data['client_port'] = self.client_address[1]

--- a/server/serverRequestHandler.py
+++ b/server/serverRequestHandler.py
@@ -66,7 +66,11 @@ class Handler(object):
 
     def heartbeat(self,msgObj,cb):
         log.debug("in heartbeat handler")
-        backend.heartbeat(msgObj[u'token'], msgObj[u'client_ip'], msgObj[u'vm_id'])
+        if 'vm_id' in msgObj:
+            backend.heartbeat(msgObj[u'token'], msgObj[u'client_ip'], msgObj[u'vm_id'])
+        else:
+            backend.heartbeat(msgObj[u'token'], msgObj[u'client_ip'])
+
         cb(204, None)
 
 


### PR DESCRIPTION
resolve #8 

@rtty122333 @woqidaideshi 

修复处理心跳的 bug。

测试：
1. 发送成功的登录请求
2. 发送只含登录返回的 `token` 的心跳
3. 应返回代码为 `204` 且无内容的回复

待补充：

增加只包含 `token` 的心跳的测试
