### PR TITLE
加入 websocket 服务，位于 /ws 路径下。原 http 接口移动到 /v1 下。

### DIFF
--- a/server/backend.py
+++ b/server/backend.py
@@ -7,7 +7,11 @@ import user_monitor
 
 log = logging.getLogger(__name__)
 
-_monitor = user_monitor.UserMonitor(timeout=30, interval=5)
+_monitor = None
+
+def init_ws(wsf):
+    global _monitor
+    _monitor = user_monitor.UserMonitor(wsf, timeout=30, interval=5)
 
 def login(username, password):
     log.info('User {} logging in'.format(username))
@@ -23,7 +27,6 @@ def login(username, password):
     except session.AuthenticationFailure as e:
         log.error(e)
         raise
-
 
 def request_connect(token, vm_id):
     try:
@@ -60,7 +63,8 @@ def init_user(token, from_ip):
     try:
         user = session.Session.get(token)
         _monitor.update_connection(user.username, from_ip)
-        _monitor.notify(user.username, True)
+        _monitor.notify(user.username, is_online=True, vm=None)
     except session.InvalidTokenError as e:
         log.error(e)
         raise
+

--- a/server/httpserver.py
+++ b/server/httpserver.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+
+import logconf
+import requesthandler
+
+from twisted.web.resource import Resource
+
+
+_handler = requesthandler.Handler()
+
+
+class VDIResource(Resource):
+
+    isLeaf = True
+
+    def render(self, request):
+        if request.method != 'POST':
+            request.setResponseCode(405) # method not allowed
+            log.warning('Invalid request method: {}'.format(request.method))
+            response = {
+                    'success': False,
+                    'error': 'InvalidRequestMethod',
+                    'error_message': "Valid request methods: POST",
+            }
+            return json.dumps(response)
+
+        datastr = request.content.getvalue()
+        data = json.loads(datastr)
+        data['client_ip'] = request.getClientIP()
+        action = request.postpath[0]
+
+        code, response = _handler.handle(action, data) 
+        request.setResponseCode(code)
+        return json.dumps(response)
+

--- a/server/wsserver.py
+++ b/server/wsserver.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+
+from autobahn.twisted.websocket import WebSocketServerFactory, \
+    WebSocketServerProtocol
+
+from server import logconf
+
+
+log = logging.getLogger(__name__)
+
+
+class WSServerProtocol(WebSocketServerProtocol):
+
+    def onConnect(self, request):
+        log.debug("Client connecting: {0}".format(request.peer))
+        self.factory.register(self)
+
+    def onOpen(self):
+        log.debug("WebSocket connection open.")
+
+    def onMessage(self, payload, isBinary):
+        if isBinary:
+            log.debug("Binary message received: {0} bytes".format(len(payload)))
+            # raise
+        else:
+            msg = payload.decode('utf-8')
+            log.debug("Text message received: {0}".format(msg))
+            try:
+                cmd = json.loads(payload)
+            except ValueError:
+                log.warning('Message is not valid JSON: {}'.format(msg))
+            else:
+                # TODO: 处理前端请求，如断开指定连接
+                if cmd['action'] == 'disconnect':
+                    # TODO
+                    self.factory.broadcast(msg, ensure_ascii=False)
+
+    def connectionLost(self, reason):
+        WebSocketServerProtocol.connectionLost(self, reason)
+        self.factory.unregister(self)
+
+    def onClose(self, wasClean, code, reason):
+        log.debug("WebSocket connection closed: {0}".format(reason))
+
+
+class BroadcastServerFactory(WebSocketServerFactory):
+
+    """
+    Simple broadcast server broadcasting any message it receives to all
+    currently connected clients.
+    """
+
+    def __init__(self, url):
+        WebSocketServerFactory.__init__(self, url)
+        self.clients = []
+        self.tickcount = 0
+        #self.tick()
+
+    def tick(self):
+        self.tickcount += 1
+        self.broadcast("tick %d from server" % self.tickcount)
+        reactor.callLater(1, self.tick)
+
+    def register(self, client):
+        if client not in self.clients:
+            log.debug("registered client {}".format(client.peer))
+            self.clients.append(client)
+
+    def unregister(self, client):
+        if client in self.clients:
+            log.debug("unregistered client {}".format(client.peer))
+            self.clients.remove(client)
+
+    def broadcast(self, msg):
+        log.debug("broadcasting message '{}' ..".format(msg))
+        for c in self.clients:
+            c.sendMessage(msg.encode('utf8'))
+            log.debug("message sent to {}".format(c.peer))
+
+
+class BroadcastPreparedServerFactory(BroadcastServerFactory):
+
+    """
+    Functionally same as above, but optimized broadcast using
+    prepareMessage and sendPreparedMessage.
+    """
+
+    def broadcast(self, msg):
+        log.debug("broadcasting prepared message '{}' ..".format(msg))
+        preparedMsg = self.prepareMessage(msg)
+        for c in self.clients:
+            c.sendPreparedMessage(preparedMsg)
+            log.debug("prepared message sent to {}".format(c.peer))
+

--- a/test/client.html
+++ b/test/client.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <script type="text/javascript">
+         var socket = null;
+         var isopen = false;
+
+         window.onload = function() {
+
+            socket = new WebSocket("ws://192.168.1.41:8893/ws");
+            socket.binaryType = "arraybuffer";
+
+            socket.onopen = function() {
+               console.log("Connected!");
+               isopen = true;
+            }
+
+            socket.onmessage = function(e) {
+               if (typeof e.data == "string") {
+                  console.log("Text message received: " + e.data);
+               } else {
+                  var arr = new Uint8Array(e.data);
+                  var hex = '';
+                  for (var i = 0; i < arr.length; i++) {
+                     hex += ('00' + arr[i].toString(16)).substr(-2);
+                  }
+                  console.log("Binary message received: " + hex);
+               }
+            }
+
+            socket.onclose = function(e) {
+               console.log("Connection closed.");
+               socket = null;
+               isopen = false;
+            }
+         };
+
+         function sendText() {
+            if (isopen) {
+               socket.send("Hello, world!");
+               console.log("Text message sent.");               
+            } else {
+               console.log("Connection not opened.")
+            }
+         };
+
+         function sendBinary() {
+            if (isopen) {
+               var buf = new ArrayBuffer(32);
+               var arr = new Uint8Array(buf);
+               for (i = 0; i < arr.length; ++i) arr[i] = i;
+               socket.send(buf);
+               console.log("Binary message sent.");
+            } else {
+               console.log("Connection not opened.")
+            }
+         };
+      </script>
+   </head>
+   <body>
+      <p>Open your browser's JavaScript console to see what's happening (hit F12).</p>
+      <button onclick='sendText();'>Send Text Message</button>
+      <button onclick='sendBinary();'>Send Binary Message</button>
+   </body>
+</html>


### PR DESCRIPTION
@rtty122333 

加入用于向界面提供连接信息的 websocket 服务，与 http 服务共用监听端口。

websocket 服务地址为 `ws://(ip):8893/ws`

原 http 服务地址改为 `http://(ip):8893/v1`

测试：
1. 将客户端代码更新到 `change-url` 分支
2. 运行服务端代码
3. 复制 `test/client.html` 到开发机器，修改其中的 `ip` 地址为实际地址
4. 在浏览器中打开 `client.html`，进入开发者工具界面，刷新，在控制台可见 `connected` 字样，服务端有对应日志输出
5. 运行客户端代码，登录、连接虚拟机、断开连接和返回登录界面都会在浏览器中有对应日志输出（后两者需要等待心跳刷新）
