### PR TITLE
响应前端断开连接请求

### DIFF
--- a/server/user_monitor.py
+++ b/server/user_monitor.py
@@ -30,9 +30,10 @@ class UserMonitor(object):
     def __del__(self):
         self.stop()
 
-    def update_connection(self, user, ip, vm=None):
+    def update_connection(self, user, ip='nochange', vm=None):
         rec = self.memo[user]
-        rec.ip = ip
+        if ip != 'nochange':
+            rec.ip = ip
         rec.vm_changed = rec.vm != vm
         rec.vm = vm
         rec.online = True
@@ -55,11 +56,13 @@ class UserMonitor(object):
                     rec.vm_changed = False
                     if not online:
                         rec.vm = None
-                    self.notify(user, online, rec.vm)
+                    self.notify(user)
             time.sleep(self.refresh_interval)
 
-    def notify(self, user, is_online, vm):
-        log.debug('======================= user {} is now {}'.format(user, 'online' if is_online else 'offline'))
+    def notify(self, user):
+        rec = self.memo[user]
+        is_online, vm = rec.online, rec.vm
+        log.debug('======================= user {} status changed. [{}][{}]'.format(user, 'ONLINE' if is_online else 'OFFLINE', vm))
         self.wsf.broadcast(json.dumps({ 'action': 'notify', 'user': user, 'online': is_online, 'vm': vm }))
 
     def start(self):

--- a/server/wsserver.py
+++ b/server/wsserver.py
@@ -6,7 +6,8 @@ import logging
 from autobahn.twisted.websocket import WebSocketServerFactory, \
     WebSocketServerProtocol
 
-from server import logconf
+import backend
+import logconf
 
 
 log = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ class WSServerProtocol(WebSocketServerProtocol):
     def onMessage(self, payload, isBinary):
         if isBinary:
             log.debug("Binary message received: {0} bytes".format(len(payload)))
-            # raise
+            # should raise
         else:
             msg = payload.decode('utf-8')
             log.debug("Text message received: {0}".format(msg))
@@ -33,10 +34,10 @@ class WSServerProtocol(WebSocketServerProtocol):
             except ValueError:
                 log.warning('Message is not valid JSON: {}'.format(msg))
             else:
-                # TODO: 处理前端请求，如断开指定连接
+                # 处理前端请求，如断开指定连接
                 if cmd['action'] == 'disconnect':
-                    # TODO
-                    self.factory.broadcast(msg, ensure_ascii=False)
+                    vm_id = cmd['vm']
+                    backend.disconnect(token='', vm_id=vm_id)
 
     def connectionLost(self, reason):
         WebSocketServerProtocol.connectionLost(self, reason)

--- a/server/wsserver.py
+++ b/server/wsserver.py
@@ -37,7 +37,8 @@ class WSServerProtocol(WebSocketServerProtocol):
                 # 处理前端请求，如断开指定连接
                 if cmd['action'] == 'disconnect':
                     vm_id = cmd['vm']
-                    backend.disconnect(token='', vm_id=vm_id)
+                    user = cmd['user']
+                    backend.disconnect_user(user, vm_id)
 
     def connectionLost(self, reason):
         WebSocketServerProtocol.connectionLost(self, reason)


### PR DESCRIPTION
@rtty122333 

收到前端界面断开桌面连接请求后，断开指定连接，并向前端发送状态更新消息。

测试：
1. 登录虚拟桌面
2. 前端界面打开连接状态页面
3. 在前端界面断开虚拟桌面连接
4. 前端能够立刻收到连接状态变化消息
