### PR TITLE
change port forward to twisted

### DIFF
--- a/server/backend.py
+++ b/server/backend.py
@@ -72,6 +72,8 @@ def request_connect(token, vm_id):
     except session.VMError as e:
         log.error('User {} attempt to connect to {} but failed: {}'.format(user.username, vm_id, e))
         raise
+    except IOError as e:
+        log.error('Cannot find free port: {}'.format(e))
 
 def disconnect_user(user, vm_id):
     # 如果是前端请求断开连接，次函数会执行两次，

--- a/server/backend.py
+++ b/server/backend.py
@@ -3,7 +3,7 @@
 import logging
 import session
 import user_monitor
-import port_forward
+import twist_forward
 
 from oslo_config import cfg
 
@@ -23,7 +23,7 @@ CONF.register_group(opt_server_group)
 CONF.register_opts(server_opts, opt_server_group)
 
 _monitor = None
-_proxy = port_forward.ServerProxy()
+_proxy = twist_forward.ForwardInst()
 
 _local_ip = CONF.server.local_ip
 
@@ -58,7 +58,7 @@ def request_connect(token, vm_id):
         ip = vm_info['floating_ips'][0]
         log.debug('vm ip: {}'.format(ip))
 
-        localport = _proxy.add_proxy(ip, 3389)
+        localport = _proxy.addProxy(ip, 3389)
 
         res[vm_id]['rdp_ip'] = _local_ip
         res[vm_id]['rdp_port'] = localport
@@ -78,7 +78,7 @@ def disconnect_user(user, vm_id):
     # 一次是响应前端请求，一次是断开之后响应客户端请求
     log.debug('disconnecting vm: {}'.format(vm_id))
     localport = _connections[vm_id]
-    _proxy.delete_proxy(localport)
+    _proxy.deleteProxy(localport)
     _monitor.update_connection(user, vm=None)
     _monitor.notify(user)
     return {'status': 'OK'}
@@ -121,7 +121,3 @@ def init_user(token, from_ip):
 def user_status():
     status = [{'user': t[0], 'vm': t[1]} for t in _monitor.status()]
     return status
-
-
-def kill_all_proxy():
-    _proxy.kill_all()

--- a/server/portforward.py
+++ b/server/portforward.py
@@ -1,0 +1,84 @@
+from twisted.internet import protocol
+from twisted.python import log
+
+class Proxy(protocol.Protocol):
+    noisy = True
+
+    peer = None
+
+    def setPeer(self, peer):
+        self.peer = peer
+
+    def connectionLost(self, reason):
+        if self.peer is not None:
+            self.peer.transport.loseConnection()
+            self.peer = None
+        elif self.noisy:
+            log.msg("Unable to connect to peer: %s" % (reason,))
+
+    def dataReceived(self, data):
+        self.peer.transport.write(data)
+
+class ProxyClient(Proxy):
+    def connectionMade(self):
+        self.peer.setPeer(self)
+
+        # Wire this and the peer transport together to enable
+        # flow control (this stops connections from filling
+        # this proxy memory when one side produces data at a
+        # higher rate than the other can consume).
+        self.transport.registerProducer(self.peer.transport, True)
+        self.peer.transport.registerProducer(self.transport, True)
+
+        # We're connected, everybody can read to their hearts content.
+        self.peer.transport.resumeProducing()
+
+class ProxyClientFactory(protocol.ClientFactory):
+
+    protocol = ProxyClient
+
+    def setServer(self, server):
+        self.server = server
+
+    def buildProtocol(self, *args, **kw):
+        prot = protocol.ClientFactory.buildProtocol(self, *args, **kw)
+        prot.setPeer(self.server)
+        return prot
+
+    def clientConnectionFailed(self, connector, reason):
+        self.server.transport.loseConnection()
+
+
+class ProxyServer(Proxy):
+
+    clientProtocolFactory = ProxyClientFactory
+    reactor = None
+
+    def connectionMade(self):
+        # Don't read anything from the connecting client until we have
+        # somewhere to send it to.
+        self.transport.pauseProducing()
+        self.factory.proxy = self
+
+        client = self.clientProtocolFactory()
+        client.setServer(self)
+
+        if self.reactor is None:
+            from twisted.internet import reactor
+            self.reactor = reactor
+        self.reactor.connectTCP(self.factory.host, self.factory.port, client)
+
+
+class ProxyFactory(protocol.Factory):
+    """Factory for port forwarder."""
+
+    protocol = ProxyServer
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.proxy = None # ProxyFactory <-> ProxyServer 1 to 1 mapping
+
+    def stop(self):
+        if self.proxy:
+            self.proxy.transport.loseConnection()

--- a/server/portforward.py
+++ b/server/portforward.py
@@ -58,7 +58,7 @@ class ProxyServer(Proxy):
         # Don't read anything from the connecting client until we have
         # somewhere to send it to.
         self.transport.pauseProducing()
-        self.factory.proxy = self
+        self.factory.proxy.append(self)
 
         client = self.clientProtocolFactory()
         client.setServer(self)
@@ -77,9 +77,9 @@ class ProxyFactory(protocol.Factory):
     def __init__(self, host, port):
         self.host = host
         self.port = port
-        self.proxy = None # ProxyFactory <-> ProxyServer 1 to 1 mapping
+        self.proxy = [] # ProxyFactory <-> ProxyServer 1 to 1 mapping
 
     def stop(self):
-        if self.proxy:
-            self.proxy.conn.disconnect()
-            self.proxy.transport.loseConnection()
+        if item in self.proxy:
+            item.conn.disconnect()
+            item.transport.loseConnection()

--- a/server/portforward.py
+++ b/server/portforward.py
@@ -66,7 +66,7 @@ class ProxyServer(Proxy):
         if self.reactor is None:
             from twisted.internet import reactor
             self.reactor = reactor
-        self.reactor.connectTCP(self.factory.host, self.factory.port, client)
+        self.conn = self.reactor.connectTCP(self.factory.host, self.factory.port, client)
 
 
 class ProxyFactory(protocol.Factory):
@@ -81,4 +81,5 @@ class ProxyFactory(protocol.Factory):
 
     def stop(self):
         if self.proxy:
+            self.proxy.conn.disconnect()
             self.proxy.transport.loseConnection()

--- a/server/portforward.py
+++ b/server/portforward.py
@@ -80,6 +80,6 @@ class ProxyFactory(protocol.Factory):
         self.proxy = [] # ProxyFactory <-> ProxyServer 1 to 1 mapping
 
     def stop(self):
-        if item in self.proxy:
+        for item in self.proxy:
             item.conn.disconnect()
             item.transport.loseConnection()

--- a/server/server.py
+++ b/server/server.py
@@ -62,4 +62,3 @@ class Server(object):
             raise
         finally:
             backend.stop_heartbeat_monitor()
-            backend.kill_all_proxy()

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -29,9 +29,12 @@ class Proxy():
 
     def __init__(self, dest_ip, dest_port, local_ip=''):
         self.tmpport = findFreePort()
-        self.new_proxy = ProxyFactory(dest_ip, dest_port)
-        self.endpoint = TCP4ServerEndpoint(reactor, self.tmpport)
-        self.endpoint.listen(self.new_proxy)
+        if self.tmpport != None:
+            self.new_proxy = ProxyFactory(dest_ip, dest_port)
+            self.endpoint = TCP4ServerEndpoint(reactor, self.tmpport)
+            self.endpoint.listen(self.new_proxy)
+        else:
+            log.error("Cannot find free port")
 
     def getport(self):
         return self.tmpport

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -47,12 +47,10 @@ class ForwardInst(Singleton):
         self.forwardlist = {}
 
     def addProxy(self, dest_ip, dest_port, local_ip=''):
-        try:
-            self.proxyinst = Proxy(dest_ip, dest_port, local_ip)
-            self.tmpport = self.proxyinst.getport()
-            self.forwardlist[self.tmpport] = self.proxyinst
-        finally:
-            return self.tmpport
+        self.proxyinst = Proxy(dest_ip, dest_port, local_ip)
+        self.tmpport = self.proxyinst.getport()
+        self.forwardlist[self.tmpport] = self.proxyinst
+        return self.tmpport
 
     def deleteProxy(self, localport):
         if self.forwardlist.has_key(localport):

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -47,14 +47,16 @@ class ForwardInst(Singleton):
         self.forwardlist = {}
 
     def addProxy(self, dest_ip, dest_port, local_ip=''):
-        self.proxyinst = Proxy(dest_ip, dest_port, local_ip)
-        self.tmpport = self.proxyinst.getport()
-        self.forwardlist[self.tmpport] = self.proxyinst
-        return self.tmpport
+        try:
+            self.proxyinst = Proxy(dest_ip, dest_port, local_ip)
+            self.tmpport = self.proxyinst.getport()
+            self.forwardlist[self.tmpport] = self.proxyinst
+        finally:
+            return self.tmpport
 
     def deleteProxy(self, localport):
         if self.forwardlist.has_key(localport):
-            del forwardlist[localport]
+            del self.forwardlist[localport]
         else:
             #此处应添加异常处理，删除不存在的端口代理
             pass

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -1,0 +1,78 @@
+import socket
+from twisted.protocols.portforward import ProxyFactory
+from twisted.internet.protocol import Protocol,Factory
+from twisted.internet import reactor
+from twisted.internet.endpoints import TCP4ServerEndpoint
+
+def findFreePort():
+    """
+    get a random avalible port
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(('localhost', 0))
+        addr, port = s.getsockname()
+        s.close()
+    except socket.error as msg:
+        log.error(msg)
+        s.close()
+    else:
+        return port
+
+class Singleton(object):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, '_inst'):
+            cls._inst=super(Singleton, cls).__new__(cls, *args, **kwargs)
+        return cls._inst
+
+class Proxy():
+
+    def __init__(self, dest_ip, dest_port, local_ip=''):
+        self.tmpport = findFreePort()
+        self.new_proxy = ProxyFactory(dest_ip, dest_port)
+        self.endpoint = TCP4ServerEndpoint(reactor, self.tmpport)
+        self.endpoint.listen(self.new_proxy)
+
+    def getport(self):
+        return self.tmpport
+
+class ForwardInst(Singleton):
+
+    def __init__(self):
+        self.forwardlist = {}
+
+    def addProxy(self, dest_ip, dest_port, local_ip=''):
+        self.proxyinst = Proxy(dest_ip, dest_port, local_ip)
+        self.tmpport = self.proxyinst.getport()
+        self.forwardlist[self.tmpport] = self.proxyinst
+        return self.tmpport
+
+    def deleteProxy(self, locolport):
+        if self.forwardlist.has_key(localport):
+            del forwardlist[localport]
+        else:
+            pass
+        
+'''
+test demo:
+class StartForward(Protocol):
+
+    def __init__(self, ports):
+        self.ports = ports
+        self.localinst = ForwardInst()
+    def connectionMade(self):
+        self.tmpport = self.localinst.addProxy('100.100.100.105',22)
+        self.transport.write("on port %s " %self.tmpport)
+        self.ports[self.tmpport] = self
+
+class ForwardFactory(Factory):
+
+    def __init__(self):
+        self.ports = {}
+
+    def buildProtocol(self, addr):
+        return StartForward(self.ports)
+
+reactor.listenTCP(8123, ForwardFactory())
+reactor.run()
+'''

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import socket
 from twisted.protocols.portforward import ProxyFactory
 from twisted.internet.protocol import Protocol,Factory
@@ -34,7 +36,7 @@ class Proxy():
             self.endpoint = TCP4ServerEndpoint(reactor, self.tmpport)
             self.endpoint.listen(self.new_proxy)
         else:
-            log.error("Cannot find free port")
+            raise IOError,("Cannot find free port")
 
     def getport(self):
         return self.tmpport

--- a/server/twist_forward.py
+++ b/server/twist_forward.py
@@ -47,10 +47,11 @@ class ForwardInst(Singleton):
         self.forwardlist[self.tmpport] = self.proxyinst
         return self.tmpport
 
-    def deleteProxy(self, locolport):
+    def deleteProxy(self, localport):
         if self.forwardlist.has_key(localport):
             del forwardlist[localport]
         else:
+            #此处应添加异常处理，删除不存在的端口代理
             pass
         
 '''


### PR DESCRIPTION
#11 @solarsail

把端口转发功能切换到用twisted的portforward实现

测试方法：

启动foldex.py，用客户端连接虚拟机。
