### PR TITLE
修复启动虚拟机失败异常

### DIFF
--- a/server/requesthandler.py
+++ b/server/requesthandler.py
@@ -60,7 +60,7 @@ class Handler(object):
             #vm未开启时需要通知nova开启
             return 200, res
         except session.VMError as e:
-            return 500, {'err': e}
+            return 500, {'err': str(e)}
 
     def disconnect_vm(self, msgObj):
         log.debug("in disconnect_vm handler")


### PR DESCRIPTION
@solarsail 

把启动虚拟机失败的异常转换为字符串

测试方法：

用客户端连接一台不可连接的虚拟机，观察server端有没有未捕获的异常
