### PR TITLE
修正在载入配置文件之前读取配置的bug

### DIFF
--- a/server/backend.py
+++ b/server/backend.py
@@ -23,6 +23,8 @@ CONF = cfg.CONF
 CONF.register_group(opt_server_group)
 CONF.register_opts(server_opts, opt_server_group)
 
+cfg.CONF(default_config_files=['/etc/foldex/foldex.conf'])
+
 _monitor = None
 _proxy = twist_forward.ForwardInst()
 


### PR DESCRIPTION
@rtty122333 

`backend.py` 在被 `import` 的时候就已经需要配置项了，但是设置配置文件位置是在 `server.py` 的 `Server.run()` 中。

在 `backend.py` 里也加入了配置文件位置的设置。

测试：
1. 将 `/etc/foldex/foldex.conf` 中 `[server]` 一节 `local_ip` 设为与代码中的默认值不同
2. 运行服务端，使用客户端登录并连接 vm，可以返回正确的本机 ip
