### PR TITLE
向客户端提供虚拟机操作系统类型信息

### DIFF
--- a/server/session.py
+++ b/server/session.py
@@ -114,6 +114,7 @@ class Session(object):
                 u'name': vm.name,
                 u'status': vm.status,
                 u'floating_ips': get_floating_ips(vm.addresses),
+                u'os': 'win'
             }
             _vm_ips[vm.id] = info[vm.id][u'floating_ips'][0] if len(info[vm.id][u'floating_ips']) > 0 else None
         return info


### PR DESCRIPTION
@rtty122333 

向客户端提供的虚拟机信息字段中加入`os`，可选值为`win`，`linux`，`mac`。

需要更新后台支持，目前硬编码为 `win`。

测试：

见 [`Foldex-Eye` PR #47](https://github.com/rtty122333/Foldex-Eye/pull/47)
